### PR TITLE
Add not-maintained note

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,27 @@ go-ipld-eth-import
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 
 > go-ipld-eth-import is the set of tools that will help us to bring the Ethereum magic to the IPLD merkle forest.
+
+## Project Status
+
+Please note that this project is **not actively maintained**.
+
+For the latest IPLD for Ethereum see:
+
+* Specification: https://ipld.io/specs/codecs/dag-eth/
+* Codec: https://github.com/vulcanize/go-codec-dageth
+
+https://github.com/vulcanize/eth-block-extractor/ is a similar project to this but is also not actively maintained, these two projects may be merged into one, or one of them retired when / if work is resumed.
+
+If you are interested in contributing to further development of this project, please open an issue for discussion, we would love to hear from you!
 
 ## Table of Contents
 
 - [Install](#install)
-- [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
-
-## Maintainers
-
-Captain: [@hermanjunge](https://github.com/hermanjunge)
 
 ## Install
 


### PR DESCRIPTION
@marten-seemann what is the standard procedure here for partial-archiving of projects? I've updated the README with a note that essentially says "if you want IPLD for Eth go here and this project isn't actively maintained but _could be revived_ at some point, please let us know if you're interested".

As per @i-norden's assessment, this project, as well as https://github.com/vulcanize/eth-block-extractor/, have potential utility but not enough users or interested parties right now to maintain their active development. However, it's very possible that this situation may change if interest in the intersection between ETH & IPLD becomes more pronounced.